### PR TITLE
One vpn subnet per host

### DIFF
--- a/01_init_cloudserver.yml
+++ b/01_init_cloudserver.yml
@@ -4,5 +4,5 @@
   gather_facts: false
   user: "{{ deploy_user }}"
   roles:
-    - { role: connection }
+    - { role: connection, tags: [ 'always' ] }
     - { role: secured_cloudserver }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 Create and deploy personal cloud servers through 
 [Hetzner Cloud](https://www.hetzner.com/de/cloud/).
-My personal setup, maybe it could become useful for somebody else. :)
+A personal setup, maybe it could become useful for somebody else. :)
+Most of the project is not specific to Hetzner. But it makes use
+of the Hetzner API to manage servers, SSH keys and DNS configuration.
+
+### References
+
+* [Hetzner API](https://docs.hetzner.cloud/)
+* [hetzner.hcloud on Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/hetzner/hcloud/docs/) 
+* [community.dns on Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/community/dns/docs/)
 
 ### Project setup
 
@@ -13,15 +21,17 @@ My personal setup, maybe it could become useful for somebody else. :)
 * Create vault: `ansible-vault create group_vars/cloudservers/vault.yml`
 * Edit vault: `ansible-vault edit group_vars/cloudservers/vault.yml`, required
   variables can be found in `vault variables` section of 
-  [main.yml](./group_vars/cloudservers/main.yml) 
+  [main.yml](./group_vars/cloudservers/main.yml). All values that originate 
+  from the vault are postfixed with `_vault`.
 
 #### Dependencies
 
-Ansible Galaxy: 
+##### Required: Install Ansible Galaxy packages
 ```shell
 ansible-galaxy install -r requirements.yml --force
 ```
 
+##### Optional: Virtual Python Environment
 Virtual Python Environment (might be necessary for `homebrew` users on macOS, 
 as for example `python-requests` and `python-dateutil` packages were disabled 
 on homebrew currently).
@@ -74,17 +84,82 @@ Credentials are created during server creation using a
 [cloud-init template](./roles/secured_cloudserver/templates/conf/cloud-init).
 Keyboard layout may be English when typing passwords.
 
+#### Hetzner DNS configuration
+
+The current implementation uses subdomains that get assigned to the cloud servers
+and the FQDN is used for SSH connections. Newly added subdomain DNS entries show 
+up very quickly, but it might still be too slow for the playbooks. Causing the
+`01_init_cloudserver.yml` playbook to fail after server creation. In this case
+just wait a few minutes until subdomains get pingable and restart the playbook.
+
 #### Wireguard vpn
 
-* The [01_init_cloudserver.yml](./01_init_cloudserver.yml) setups all servers 
+* The [01_init_cloudserver.yml](./01_init_cloudserver.yml) sets up all servers 
   including Wireguard and disables public SSH access. Make sure to always have at
   least one Wireguard client configured.
- 
-* A single Wireguard client config might be shared on multiple devices, as long they
-  are not used at the same time.
 
 * You can use `ansible-playbook 01_init_cloudserver.yml -t wgclients` to print
   all client configs (plain text config files and QR codes).
 
 * Playbooks will try to connect via VPN first and fallback to public SSH, if VPN
   connection is not available.
+
+* A single Wireguard client config might be shared on multiple devices, as long they
+  are not used at the same time.
+
+* For the sake of simplicity the same server and client keys are used on all
+  hosts defined in the [main.yml](./group_vars/cloudservers/main.yml). This works
+  fine, as long each server uses a different endpoint.
+
+#### Multiple Wireguard connections on macOS
+
+MacOS allows the creation of multiple vpn connections and also to enable them
+simultaneously. But this leads to only one working connection at the same time
+silently. This has been discussed on Apple Developer forums:
+https://forums.developer.apple.com/forums/thread/687371
+
+> You will find that on both macOS and iOS as soon as you start another instance of
+> a NEPacketTunnelProvider it will take precedence over the previously running 
+> NEPacketTunnelProvider instance.
+
+As the official [Wireguard app](https://apps.apple.com/de/app/wireguard/id1451685025) 
+uses the macOS network stack, it can only be used for a single connection.
+For multiple simultaneous connections use Wireguard via [Homebrew](https://brew.sh). 
+
+```shell
+# Install Wireguard
+brew install wireguard-tools
+```
+
+This way you can use more than one Wireguard connection at a time:
+
+```shell
+# Copy Wireguard client config from the playbooks output
+# to a arbitrary location
+nano /Users/myuser/Downloads/wg0.conf
+nano /Users/myuser/Downloads/wg1.conf
+
+# Start tunnels
+sudo wg-quick up /Users/myuser/Downloads/wg0.conf
+sudo wg-quick up /Users/myuser/Downloads/wg1.conf
+
+# Stop tunnels
+sudo wg-quick down /Users/myuser/Downloads/wg0.conf
+sudo wg-quick down /Users/myuser/Downloads/wg1.conf
+```
+
+alternatively 
+
+```shell
+# Copy Wireguard to /opt/homebrew/etc/wireguard
+nano /opt/homebrew/etc/wireguard/wg0.conf
+nano /opt/homebrew/etc/wireguard/wg1.conf
+
+# Start tunnels
+sudo wg-quick up wg0
+sudo wg-quick up wg1
+
+# Stop tunnels
+sudo wg-quick down wg0
+sudo wg-quick down wg1
+```

--- a/group_vars/cloudservers/main.yml
+++ b/group_vars/cloudservers/main.yml
@@ -11,9 +11,5 @@ deploy_user_sshkey: "{{ deploy_user_sshkey_vault }}"
 deploy_user_sshkey_name: "{{ deploy_user_sshkey_name_vault }}"
 deploy_user_password: "{{ deploy_user_password_vault }}"
 
-# Wireguard
-wireguard_server_privkey: "{{ wireguard_server_privkey_vault }}"
-wireguard_server_pubkey: "{{ wireguard_server_pubkey_vault }}"
-
 ### Public variables
 ansible_become_pass: "{{ deploy_user_password }}"

--- a/group_vars/cloudservers/main.yml
+++ b/group_vars/cloudservers/main.yml
@@ -1,11 +1,9 @@
 ### Vault variables
 global_domain: "{{ global_domain_vault }}"
 
-# Hetzner Tokens
 hetzner_cloud_token: "{{ hetzner_cloud_token_vault }}"
 hetzner_dns_token : "{{ hetzner_dns_token_vault }}"
 
-# Deployment User
 deploy_user: "{{ deploy_user_vault }}"
 deploy_user_sshkey: "{{ deploy_user_sshkey_vault }}"
 deploy_user_sshkey_name: "{{ deploy_user_sshkey_name_vault }}"

--- a/group_vars/cloudservers/wireguard.yml
+++ b/group_vars/cloudservers/wireguard.yml
@@ -1,14 +1,14 @@
-# global Wireguard config
-wireguard_port: 2020
+# Wireguard config
 wireguard_interface: wg0
+wireguard_port: 2020
 
-wireguard_server_privkey: "{{ wireguard_server_privkey_vault }}"
-wireguard_server_pubkey: "{{ wireguard_server_pubkey_vault }}"
+wireguard_server_privkey: "{{ wireguard_privkey_vault }}"
+wireguard_server_pubkey: "{{ wireguard_pubkey_vault }}"
 
 wireguard_clients: [
   {
-    "publickey" : "{{ wg_client1_pubkey_vault }}",
+    "device": "{{ wg_client1_name_vault }}",
+    "publickey": "{{ wg_client1_pubkey_vault }}",
     "privatekey" : "{{ wg_client1_privkey_vault }}",
     "allowedIps" : "{{ wireguard_server_net }}.101",
-    "device": "{{ wg_client1_name }}"
   }]

--- a/group_vars/cloudservers/wireguard.yml
+++ b/group_vars/cloudservers/wireguard.yml
@@ -6,9 +6,9 @@ wireguard_server_privkey: "{{ wireguard_server_privkey_vault }}"
 wireguard_server_pubkey: "{{ wireguard_server_pubkey_vault }}"
 
 wireguard_clients: [
-{
-  "publickey" : "{{ wg_client1_pubkey_vault }}",
-  "privatekey" : "{{ wg_client1_privkey_vault }}",
-  "allowedIps" : "{{ wireguard_server_net }}.101",
-  "device": "{{ wg_client1_name }}"
-}]
+  {
+    "publickey" : "{{ wg_client1_pubkey_vault }}",
+    "privatekey" : "{{ wg_client1_privkey_vault }}",
+    "allowedIps" : "{{ hostvars[inventory_hostname].wireguard_server_net }}.101",
+    "device": "{{ wg_client1_name }}"
+  }]

--- a/group_vars/cloudservers/wireguard.yml
+++ b/group_vars/cloudservers/wireguard.yml
@@ -9,6 +9,6 @@ wireguard_clients: [
   {
     "publickey" : "{{ wg_client1_pubkey_vault }}",
     "privatekey" : "{{ wg_client1_privkey_vault }}",
-    "allowedIps" : "{{ hostvars[inventory_hostname].wireguard_server_net }}.101",
+    "allowedIps" : "{{ wireguard_server_net }}.101",
     "device": "{{ wg_client1_name }}"
   }]

--- a/group_vars/cloudservers/wireguard.yml
+++ b/group_vars/cloudservers/wireguard.yml
@@ -1,10 +1,6 @@
-# Wireguard
+# global Wireguard config
 wireguard_port: 2020
 wireguard_interface: wg0
-wireguard_server_net: "10.10.10"
-wireguard_server_netmask: "24"
-wireguard_server_net_with_mask: "{{ wireguard_server_net }}.0/{{ wireguard_server_netmask}}"
-wireguard_server_address: "{{ wireguard_server_net }}.1/{{ wireguard_server_netmask}}"
 
 wireguard_server_privkey: "{{ wireguard_server_privkey_vault }}"
 wireguard_server_pubkey: "{{ wireguard_server_pubkey_vault }}"
@@ -15,5 +11,4 @@ wireguard_clients: [
   "privatekey" : "{{ wg_client1_privkey_vault }}",
   "allowedIps" : "{{ wireguard_server_net }}.101",
   "device": "{{ wg_client1_name }}"
-}
-]
+}]

--- a/hosts/inventory.yml
+++ b/hosts/inventory.yml
@@ -14,10 +14,15 @@ all:
             hetzner_enable_ipv4: true
             hetzner_enable_ipv6: false
             hetzner_enable_backups: false
-            vpn_ansible_host: "10.10.10.1"
+            wireguard_subnet: 1
             ## TODO: ip route list default
             public_network_interface: eth0
   vars:
     public_dns_name : "{{ hostvars[inventory_hostname].vars.hetzner_dns_record }}"
     host_domain: "{{ global_domain }}"
+    # Host-specific Wireguard configuration
+    wireguard_server_net_mask: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}.0/24"
+    wireguard_server_address: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}.1"
+    # Hosts used for Ansible connections
     ansible_host: "{{ hostvars[inventory_hostname].vars.public_dns_name }}"
+    vpn_ansible_host: "{{ wireguard_server_address }}"

--- a/hosts/inventory.yml
+++ b/hosts/inventory.yml
@@ -21,8 +21,9 @@ all:
     public_dns_name : "{{ hostvars[inventory_hostname].vars.hetzner_dns_record }}"
     host_domain: "{{ global_domain }}"
     # Host-specific Wireguard configuration
-    wireguard_server_net_mask: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}.0/24"
-    wireguard_server_address: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}.1"
+    wireguard_server_net: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}"
+    wireguard_server_address: "{{ hostvars[inventory_hostname].vars.wireguard_server_net }}.1"
+    wireguard_server_net_mask: "{{ hostvars[inventory_hostname].vars.wireguard_server_net }}.0/24"
     # Hosts used for Ansible connections
     ansible_host: "{{ hostvars[inventory_hostname].vars.public_dns_name }}"
     vpn_ansible_host: "{{ wireguard_server_address }}"

--- a/hosts/inventory.yml
+++ b/hosts/inventory.yml
@@ -4,7 +4,6 @@ all:
       hosts:
         connect:
           vars:
-            public_dns_name: "{{ inventory_hostname_short }}.{{ global_domain }}"
             hetzner_dns_zone: "{{ global_domain }}"
             hetzner_dns_record: "{{ inventory_hostname_short }}.{{ global_domain }}"
             hetzner_name: Cloudserver-1
@@ -14,16 +13,9 @@ all:
             hetzner_enable_ipv4: true
             hetzner_enable_ipv6: false
             hetzner_enable_backups: false
-            wireguard_subnet: 1
             ## TODO: ip route list default
             public_network_interface: eth0
+            wireguard_subnet: 1
   vars:
-    public_dns_name : "{{ hostvars[inventory_hostname].vars.hetzner_dns_record }}"
+    public_dns_name : "{{ inventory_hostname_short }}.{{ global_domain }}"
     host_domain: "{{ global_domain }}"
-    # Host-specific Wireguard configuration
-    wireguard_server_net: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}"
-    wireguard_server_address: "{{ hostvars[inventory_hostname].vars.wireguard_server_net }}.1"
-    wireguard_server_net_mask: "{{ hostvars[inventory_hostname].vars.wireguard_server_net }}.0/24"
-    # Hosts used for Ansible connections
-    ansible_host: "{{ hostvars[inventory_hostname].vars.public_dns_name }}"
-    vpn_ansible_host: "{{ wireguard_server_address }}"

--- a/hosts/inventory.yml
+++ b/hosts/inventory.yml
@@ -16,20 +16,6 @@ all:
             ## TODO: ip route list default
             public_network_interface: eth0
             wireguard_subnet: 1
-        disconnect:
-          vars:
-            hetzner_dns_zone: "{{ global_domain }}"
-            hetzner_dns_record: "{{ inventory_hostname_short }}.{{ global_domain }}"
-            hetzner_name: Cloudserver-2
-            hetzner_location: fsn1
-            hetzner_type: cx22
-            hetzner_image: ubuntu-24.04
-            hetzner_enable_ipv4: true
-            hetzner_enable_ipv6: false
-            hetzner_enable_backups: false
-            ## TODO: ip route list default
-            public_network_interface: eth0
-            wireguard_subnet: 2
   vars:
     public_dns_name : "{{ inventory_hostname_short }}.{{ global_domain }}"
     host_domain: "{{ global_domain }}"

--- a/hosts/inventory.yml
+++ b/hosts/inventory.yml
@@ -16,6 +16,20 @@ all:
             ## TODO: ip route list default
             public_network_interface: eth0
             wireguard_subnet: 1
+        disconnect:
+          vars:
+            hetzner_dns_zone: "{{ global_domain }}"
+            hetzner_dns_record: "{{ inventory_hostname_short }}.{{ global_domain }}"
+            hetzner_name: Cloudserver-2
+            hetzner_location: fsn1
+            hetzner_type: cx22
+            hetzner_image: ubuntu-24.04
+            hetzner_enable_ipv4: true
+            hetzner_enable_ipv6: false
+            hetzner_enable_backups: false
+            ## TODO: ip route list default
+            public_network_interface: eth0
+            wireguard_subnet: 2
   vars:
     public_dns_name : "{{ inventory_hostname_short }}.{{ global_domain }}"
     host_domain: "{{ global_domain }}"

--- a/roles/connection/tasks/main.yml
+++ b/roles/connection/tasks/main.yml
@@ -1,9 +1,18 @@
 ---
+- name: Set Wireguard config 1
+  ansible.builtin.set_fact:
+    wireguard_server_net: "10.10.{{ hostvars[inventory_hostname].vars.wireguard_subnet }}"
+
+- name: Set Wireguard config 2
+  ansible.builtin.set_fact:
+    wireguard_server_address: "{{ wireguard_server_net }}.1"
+    wireguard_server_net_mask: "{{ wireguard_server_net }}.0/24"
+
 - name: Determine SSH connection (VPN or public)
   block:
     - name: Try SSH via VPN
       set_fact:
-        ansible_host: "{{ hostvars[inventory_hostname].vars.vpn_ansible_host }}"
+        ansible_host: "{{ wireguard_server_address }}"
     - name: Test for VPN SSH connection, this might fail (wait up to 20 seconds)
       ansible.builtin.wait_for_connection:
         delay: 0
@@ -21,13 +30,13 @@
         msg: "VPN SSH failed"
     - name: Fallback to public SSH connection
       set_fact:
-        ansible_host: "{{ hostvars[inventory_hostname].vars.public_dns_name }}"
-- name: Final test for SSH connection (wait up to 20 seconds)
-  ansible.builtin.wait_for_connection:
-    delay: 0
-    sleep: 0
-    connect_timeout: 10
-    timeout: 20
-  retries: 0
-  delay: 0
-  ignore_unreachable: true
+        ansible_host: "{{ hostvars[inventory_hostname].public_dns_name }}"
+#- name: Final test for SSH connection (wait up to 20 seconds)
+#  ansible.builtin.wait_for_connection:
+#    delay: 0
+#    sleep: 0
+#    connect_timeout: 10
+#    timeout: 20
+#  retries: 0
+#  delay: 0
+#  ignore_unreachable: true

--- a/roles/secured_cloudserver/tasks/00_preflight_checks.yml
+++ b/roles/secured_cloudserver/tasks/00_preflight_checks.yml
@@ -11,3 +11,11 @@
       ==
       hostvars | dict2items | map(attribute="value.vars.wireguard_subnet") | list | unique | count
     fail_msg: "Each host requires its own Wireguard subnet, wireguard_subnet needs to be unique!"
+
+- name: Check each host has a unique name (as it identifies the server on Hetzner API)
+  ansible.builtin.assert:
+    that: >
+      hostvars | dict2items | map(attribute="value.vars.hetzner_name") | list | count
+      ==
+      hostvars | dict2items | map(attribute="value.vars.hetzner_name") | list | unique | count
+    fail_msg: "Each host requires a unique name, hetzner_name needs to be unique!"

--- a/roles/secured_cloudserver/tasks/00_preflight_checks.yml
+++ b/roles/secured_cloudserver/tasks/00_preflight_checks.yml
@@ -1,5 +1,13 @@
 ---
-- name: A single condition can be supplied as string instead of list
+- name: Check at least on Wireguard client exists
   ansible.builtin.assert:
     that: "{{ wireguard_clients | length }} > 0"
     fail_msg: "At least one Wireguard client is required!"
+
+- name: Check each host has its own Wireguard subnet
+  ansible.builtin.assert:
+    that: >
+      hostvars | dict2items | map(attribute="value.vars.wireguard_subnet") | list | count
+      ==
+      hostvars | dict2items | map(attribute="value.vars.wireguard_subnet") | list | unique | count
+    fail_msg: "Each host requires its own Wireguard subnet, wireguard_subnet needs to be unique!"

--- a/roles/secured_cloudserver/templates/conf/wg-client.conf
+++ b/roles/secured_cloudserver/templates/conf/wg-client.conf
@@ -5,6 +5,6 @@ Address = {{ item.allowedIps }}/32
 
 [Peer]
 PublicKey = {{ wireguard_server_pubkey }}
-AllowedIPs = {{ hostvars[inventory_hostname].vars.wireguard_server_address }}
-Endpoint = {{ hostvars[inventory_hostname].vars.public_dns_name }}:{{ wireguard_port }}
+AllowedIPs = {{ hostvars[inventory_hostname].wireguard_server_address }}
+Endpoint = {{ hostvars[inventory_hostname].public_dns_name }}:{{ wireguard_port }}
 PersistentKeepalive = 30

--- a/roles/secured_cloudserver/templates/conf/wg-client.conf
+++ b/roles/secured_cloudserver/templates/conf/wg-client.conf
@@ -5,6 +5,6 @@ Address = {{ item.allowedIps }}/32
 
 [Peer]
 PublicKey = {{ wireguard_server_pubkey }}
-AllowedIPs = {{ wireguard_server_net_with_mask }}
+AllowedIPs = {{ hostvars[inventory_hostname].vars.wireguard_server_address }}
 Endpoint = {{ hostvars[inventory_hostname].vars.public_dns_name }}:{{ wireguard_port }}
 PersistentKeepalive = 30

--- a/roles/secured_cloudserver/templates/conf/wg0-server.conf
+++ b/roles/secured_cloudserver/templates/conf/wg0-server.conf
@@ -1,6 +1,6 @@
 [Interface]
 PrivateKey = {{ wireguard_server_privkey }}
-Address = {{ hostvars[inventory_hostname].vars.wireguard_server_address }}
+Address = {{ hostvars[inventory_hostname].wireguard_server_address }}
 ListenPort = {{ wireguard_port }}
 SaveConfig = false
 

--- a/roles/secured_cloudserver/templates/conf/wg0-server.conf
+++ b/roles/secured_cloudserver/templates/conf/wg0-server.conf
@@ -1,6 +1,6 @@
 [Interface]
 PrivateKey = {{ wireguard_server_privkey }}
-Address = {{ wireguard_server_address }}
+Address = {{ hostvars[inventory_hostname].vars.wireguard_server_address }}
 ListenPort = {{ wireguard_port }}
 SaveConfig = false
 


### PR DESCRIPTION
Refactor Wireguard config, each host gets its own wireguard subnet:
- each server has its own Wireguard net, so they can be completely independent of each other
- each server has its own network, allowing to open tunnels from client to each server at the same time
- the target setup is to have a handful of servers (in private projects) in worst case, so this seems to be a valid approach